### PR TITLE
Add setup py endpoint

### DIFF
--- a/UniqueIDServer.py
+++ b/UniqueIDServer.py
@@ -16,33 +16,16 @@ The Response:
 {"endIndex": 9, "startIndex": 0}
 {"endIndex": 9, "startIndex": 0}
 """
-from json import dumps
 import cherrypy
+from uniqueid.globals import CHERRYPY_CONFIG
+from uniqueid import main, error_page_default
 from uniqueid.rest import Root
-from uniqueid.orm import create_tables
-
-
-def error_page_default(**kwargs):
-    """The default error page should always enforce json."""
-    cherrypy.response.headers['Content-Type'] = 'application/json'
-    return dumps({
-        'status': kwargs['status'],
-        'message': kwargs['message'],
-        'traceback': kwargs['traceback'],
-        'version': kwargs['version']
-    })
-
-
-def main():
-    """Main method to start the httpd server."""
-    create_tables()
-    cherrypy.quickstart(Root(), '/', 'server.conf')
 
 
 cherrypy.config.update({'error_page.default': error_page_default})
 # pylint doesn't realize that application is actually a callable
 # pylint: disable=invalid-name
-application = cherrypy.Application(Root(), '/', 'server.conf')
+application = cherrypy.Application(Root(), '/', CHERRYPY_CONFIG)
 # pylint: enable=invalid-name
 if __name__ == '__main__':  # pragma no branch
     main()

--- a/setup.py
+++ b/setup.py
@@ -12,5 +12,8 @@ setup(name='PacificaUniqueID',
       author='David Brown',
       author_email='david.brown@pnnl.gov',
       packages=['uniqueid', 'uniqueid.test'],
+      entry_point={
+          'console_scripts': ['UniqueIDServer=uniqueid:main']
+      },
       scripts=['UniqueIDServer.py', 'DatabaseCreate.py'],
       install_requires=[str(ir.req) for ir in INSTALL_REQS])

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,6 @@ setup(name='PacificaUniqueID',
       description='Pacifica UniqueID',
       author='David Brown',
       author_email='david.brown@pnnl.gov',
-      packages=['uniqueid'],
+      packages=['uniqueid', 'uniqueid.test'],
       scripts=['UniqueIDServer.py', 'DatabaseCreate.py'],
       install_requires=[str(ir.req) for ir in INSTALL_REQS])

--- a/uniqueid/__init__.py
+++ b/uniqueid/__init__.py
@@ -1,2 +1,40 @@
 #!/usr/bin/python
-"""Unique ID module."""
+"""UniqueID Module."""
+from argparse import ArgumentParser
+from json import dumps
+import cherrypy
+from uniqueid.globals import CHERRYPY_CONFIG
+from uniqueid.rest import Root
+from uniqueid.orm import create_tables
+
+
+def error_page_default(**kwargs):
+    """The default error page should always enforce json."""
+    cherrypy.response.headers['Content-Type'] = 'application/json'
+    return dumps({
+        'status': kwargs['status'],
+        'message': kwargs['message'],
+        'traceback': kwargs['traceback'],
+        'version': kwargs['version']
+    })
+
+
+def main():
+    """Main method to start the httpd server."""
+    parser = ArgumentParser(description='Run the uniqueid server.')
+    parser.add_argument('-c', '--config', metavar='CONFIG', type=str,
+                        default=CHERRYPY_CONFIG, dest='config',
+                        help='cherrypy config file')
+    parser.add_argument('-p', '--port', metavar='PORT', type=int,
+                        default=8051, dest='port',
+                        help='port to listen on')
+    parser.add_argument('-a', '--address', metavar='ADDRESS',
+                        default='localhost', dest='address',
+                        help='address to listen on')
+    args = parser.parse_args()
+    create_tables()
+    cherrypy.config.update({
+        'server.socket_host': args.address,
+        'server.socket_port': args.port
+    })
+    cherrypy.quickstart(Root(), '/', args.config)

--- a/uniqueid/globals.py
+++ b/uniqueid/globals.py
@@ -1,0 +1,6 @@
+#!/usr/bin/python
+"""Global module for static variables."""
+from os import getenv
+
+
+CHERRYPY_CONFIG = getenv('CHERRYPY_CONFIG', 'server.conf')


### PR DESCRIPTION
### Description

This adds setup.py endpoint and makes cherrypy config a global parameter to set
### Issues Resolved

N/A
### Check List

- [x] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
